### PR TITLE
Create peripheral_ADC

### DIFF
--- a/peripheral_ADC
+++ b/peripheral_ADC
@@ -1,0 +1,1 @@
+dasdasd


### PR DESCRIPTION
Modulo que se encarga de procesar las señales analógicas provenientes de los fotoresistores para su posterior uso en el control de motores.
